### PR TITLE
feat: add JWT authentication with register and login

### DIFF
--- a/backend/src/taskflow/auth.py
+++ b/backend/src/taskflow/auth.py
@@ -1,0 +1,102 @@
+"""JWT authentication module for TaskFlow API."""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from .database import get_db
+from .db_models import UserModel
+
+SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plain-text password using bcrypt."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plain-text password against a bcrypt hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(
+    data: dict, expires_delta: timedelta | None = None
+) -> str:
+    """Create a signed JWT access token.
+
+    Args:
+        data: Claims to encode in the token.
+        expires_delta: Optional custom expiration. Defaults to ACCESS_TOKEN_EXPIRE_MINUTES.
+
+    Returns:
+        Encoded JWT string.
+    """
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (
+        expires_delta if expires_delta else timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str) -> dict:
+    """Decode and validate a JWT access token.
+
+    Args:
+        token: Encoded JWT string.
+
+    Returns:
+        Decoded token payload.
+
+    Raises:
+        HTTPException: 401 if the token is invalid or expired.
+    """
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload
+    except JWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+
+def get_current_user(
+    token: str = Depends(oauth2_scheme),
+    db: Session = Depends(get_db),
+) -> UserModel:
+    """Extract the current authenticated user from the JWT token.
+
+    FastAPI dependency that decodes the bearer token and retrieves the user.
+
+    Raises:
+        HTTPException: 401 if the token is invalid or user not found.
+    """
+    payload = decode_access_token(token)
+    username: str | None = payload.get("sub")
+    if username is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    user = db.query(UserModel).filter(UserModel.username == username).first()
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return user

--- a/backend/src/taskflow/auth_router.py
+++ b/backend/src/taskflow/auth_router.py
@@ -1,0 +1,65 @@
+"""Authentication router for TaskFlow API."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from .auth import create_access_token, hash_password, verify_password
+from .database import get_db
+from .db_models import UserModel
+from .schemas import UserCreate, UserResponse
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+def register(user_data: UserCreate, db: Session = Depends(get_db)) -> UserModel:
+    """Register a new user account.
+
+    Creates a user with a hashed password and returns the user profile.
+
+    Raises:
+        HTTPException: 400 if username or email already exists.
+    """
+    existing = db.query(UserModel).filter(
+        (UserModel.username == user_data.username) | (UserModel.email == user_data.email)
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Username or email already registered",
+        )
+
+    user = UserModel(
+        username=user_data.username,
+        email=user_data.email,
+        hashed_password=hash_password(user_data.password),
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@router.post("/login")
+def login(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Authenticate a user and return a JWT access token.
+
+    Accepts OAuth2-compatible form data (username + password).
+
+    Raises:
+        HTTPException: 401 if credentials are invalid.
+    """
+    user = db.query(UserModel).filter(UserModel.username == form_data.username).first()
+    if not user or not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    access_token = create_access_token(data={"sub": user.username})
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,203 @@
+"""Tests for JWT authentication and auth endpoints."""
+
+from datetime import timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from taskflow.auth import (
+    create_access_token,
+    decode_access_token,
+    hash_password,
+    verify_password,
+)
+from taskflow.auth_router import router
+from taskflow.database import Base, get_db
+
+
+@pytest.fixture()
+def db_engine():
+    """Create an in-memory SQLite engine shared across threads."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield engine
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture()
+def db_session(db_engine) -> Session:
+    """Create a database session for testing."""
+    testing_session = sessionmaker(autocommit=False, autoflush=False, bind=db_engine)
+    session = testing_session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_engine, db_session: Session) -> TestClient:
+    """Create a FastAPI test client with database dependency override."""
+    app = FastAPI()
+    app.include_router(router)
+
+    def _override_get_db() -> Session:
+        session = sessionmaker(autocommit=False, autoflush=False, bind=db_engine)()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return TestClient(app)
+
+
+# --- Password hashing tests ---
+
+
+def test_should_hash_and_verify_password() -> None:
+    """Verify that a password can be hashed and verified."""
+    hashed = hash_password("mysecretpassword")
+    assert hashed != "mysecretpassword"
+    assert verify_password("mysecretpassword", hashed) is True
+
+
+def test_should_reject_wrong_password() -> None:
+    """Verify that an incorrect password fails verification."""
+    hashed = hash_password("correct-password")
+    assert verify_password("wrong-password", hashed) is False
+
+
+# --- Token creation and decoding tests ---
+
+
+def test_should_create_and_decode_token() -> None:
+    """Verify that a token can be created and decoded with correct claims."""
+    token = create_access_token(data={"sub": "alice"})
+    payload = decode_access_token(token)
+    assert payload["sub"] == "alice"
+    assert "exp" in payload
+
+
+def test_should_create_token_with_custom_expiry() -> None:
+    """Verify that a token respects custom expiration delta."""
+    token = create_access_token(
+        data={"sub": "bob"}, expires_delta=timedelta(minutes=5)
+    )
+    payload = decode_access_token(token)
+    assert payload["sub"] == "bob"
+
+
+def test_should_reject_expired_token() -> None:
+    """Verify that an expired token raises HTTPException 401."""
+    token = create_access_token(
+        data={"sub": "carol"}, expires_delta=timedelta(seconds=-1)
+    )
+    with pytest.raises(Exception) as exc_info:
+        decode_access_token(token)
+    assert exc_info.value.status_code == 401
+
+
+def test_should_reject_invalid_token() -> None:
+    """Verify that a tampered token raises HTTPException 401."""
+    with pytest.raises(Exception) as exc_info:
+        decode_access_token("not-a-valid-token")
+    assert exc_info.value.status_code == 401
+
+
+# --- Register endpoint tests ---
+
+
+def test_should_register_user(client: TestClient) -> None:
+    """Verify that POST /auth/register creates a user and returns profile."""
+    response = client.post(
+        "/auth/register",
+        json={
+            "username": "testuser",
+            "email": "test@example.com",
+            "password": "securepassword123",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["username"] == "testuser"
+    assert data["email"] == "test@example.com"
+    assert "id" in data
+    assert "created_at" in data
+    assert "password" not in data
+    assert "hashed_password" not in data
+
+
+def test_should_reject_duplicate_registration(client: TestClient) -> None:
+    """Verify that registering with an existing username/email returns 400."""
+    payload = {
+        "username": "duplicate",
+        "email": "dup@example.com",
+        "password": "securepassword123",
+    }
+    client.post("/auth/register", json=payload)
+    response = client.post("/auth/register", json=payload)
+    assert response.status_code == 400
+    assert "already registered" in response.json()["detail"]
+
+
+# --- Login endpoint tests ---
+
+
+def test_should_login_with_valid_credentials(client: TestClient) -> None:
+    """Verify that POST /auth/login returns an access token."""
+    client.post(
+        "/auth/register",
+        json={
+            "username": "loginuser",
+            "email": "login@example.com",
+            "password": "securepassword123",
+        },
+    )
+    response = client.post(
+        "/auth/login",
+        data={"username": "loginuser", "password": "securepassword123"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+    # Verify the token is valid and contains the correct subject
+    payload = decode_access_token(data["access_token"])
+    assert payload["sub"] == "loginuser"
+
+
+def test_should_reject_login_with_wrong_password(client: TestClient) -> None:
+    """Verify that login with wrong password returns 401."""
+    client.post(
+        "/auth/register",
+        json={
+            "username": "wrongpw",
+            "email": "wrongpw@example.com",
+            "password": "correctpassword123",
+        },
+    )
+    response = client.post(
+        "/auth/login",
+        data={"username": "wrongpw", "password": "wrongpassword"},
+    )
+    assert response.status_code == 401
+    assert "Incorrect username or password" in response.json()["detail"]
+
+
+def test_should_reject_login_with_nonexistent_user(client: TestClient) -> None:
+    """Verify that login with nonexistent user returns 401."""
+    response = client.post(
+        "/auth/login",
+        data={"username": "ghost", "password": "doesnotmatter"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

- Add `auth.py` with JWT token creation/decoding via python-jose, bcrypt password hashing via passlib, OAuth2PasswordBearer scheme, and `get_current_user` FastAPI dependency
- Add `auth_router.py` with `POST /auth/register` (creates user, returns UserResponse) and `POST /auth/login` (OAuth2 form, returns access_token)
- Add `test_auth.py` with 11 tests covering password hashing, token lifecycle (create, decode, expired, invalid), user registration, login success, and login failure scenarios

Closes #4

## Test plan

- [x] `pytest tests/test_auth.py -v` -- 11/11 tests passing
- [x] Password hashing and verification with bcrypt
- [x] JWT token creation with default and custom expiry
- [x] Expired and invalid token rejection (401)
- [x] User registration via POST /auth/register (201, duplicate detection 400)
- [x] Login via POST /auth/login (200 with token, 401 on wrong credentials)
- [x] Full test suite: 66/66 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)