### PR TITLE
feat: add FastAPI task endpoints and app setup (task-05)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "passlib[bcrypt]",
     "bcrypt<4.1",
     "uvicorn",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/taskflow/app.py
+++ b/backend/src/taskflow/app.py
@@ -1,0 +1,37 @@
+"""FastAPI application for TaskFlow API."""
+
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
+
+from fastapi import FastAPI
+
+from .auth_router import router as auth_router
+from .database import create_tables
+from .task_router import router as task_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Create database tables on startup."""
+    create_tables()
+    yield
+
+
+app = FastAPI(
+    title="TaskFlow API",
+    version="1.0.0",
+    lifespan=lifespan,
+)
+
+app.include_router(auth_router)
+app.include_router(task_router)
+
+
+@app.get("/")
+def root() -> dict:
+    """Return API information."""
+    return {
+        "name": "TaskFlow API",
+        "version": "1.0.0",
+        "docs": "/docs",
+    }

--- a/backend/src/taskflow/task_router.py
+++ b/backend/src/taskflow/task_router.py
@@ -1,0 +1,102 @@
+"""Task endpoints router for TaskFlow API."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from .auth import get_current_user
+from .database import get_db
+from .db_models import TaskModel, UserModel
+from .repositories import TaskRepository
+from .schemas import TaskCreate, TaskResponse, TaskUpdate
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.get("/", response_model=list[TaskResponse])
+def list_tasks(
+    skip: int = Query(default=0, ge=0),
+    limit: int = Query(default=100, ge=1, le=100),
+    db: Session = Depends(get_db),
+) -> list[TaskModel]:
+    """List all tasks with pagination."""
+    return TaskRepository.list_all(db, skip=skip, limit=limit)
+
+
+@router.get("/{task_id}", response_model=TaskResponse)
+def get_task(task_id: int, db: Session = Depends(get_db)) -> TaskModel:
+    """Get a task by its ID.
+
+    Raises:
+        HTTPException: 404 if the task does not exist.
+    """
+    task = TaskRepository.get_by_id(db, task_id)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+    return task
+
+
+@router.post("/", response_model=TaskResponse, status_code=status.HTTP_201_CREATED)
+def create_task(
+    task_data: TaskCreate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> TaskModel:
+    """Create a new task owned by the authenticated user."""
+    return TaskRepository.create(db, task_data, owner_id=current_user.id)
+
+
+@router.put("/{task_id}", response_model=TaskResponse)
+def update_task(
+    task_id: int,
+    task_data: TaskUpdate,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> TaskModel:
+    """Update a task. Only the task owner can update it.
+
+    Raises:
+        HTTPException: 404 if the task does not exist.
+        HTTPException: 403 if the current user is not the owner.
+    """
+    task = TaskRepository.get_by_id(db, task_id)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+    if task.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to update this task",
+        )
+    updated = TaskRepository.update(db, task_id, task_data)
+    return updated  # type: ignore[return-value]
+
+
+@router.delete("/{task_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_task(
+    task_id: int,
+    db: Session = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> None:
+    """Delete a task. Only the task owner can delete it.
+
+    Raises:
+        HTTPException: 404 if the task does not exist.
+        HTTPException: 403 if the current user is not the owner.
+    """
+    task = TaskRepository.get_by_id(db, task_id)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+    if task.owner_id != current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to delete this task",
+        )
+    TaskRepository.delete(db, task_id)

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,0 +1,286 @@
+"""Integration tests for TaskFlow API endpoints."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from taskflow.app import app
+from taskflow.database import Base, get_db
+
+
+@pytest.fixture()
+def client():
+    """Create a test client with an in-memory SQLite database."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    def override_get_db():
+        session = TestingSession()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def auth_headers(client: TestClient) -> dict:
+    """Register a user and return auth headers with JWT token."""
+    client.post(
+        "/auth/register",
+        json={
+            "username": "testuser",
+            "email": "test@example.com",
+            "password": "securepass123",
+        },
+    )
+    response = client.post(
+        "/auth/login",
+        data={"username": "testuser", "password": "securepass123"},
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def other_auth_headers(client: TestClient) -> dict:
+    """Register a second user and return auth headers."""
+    client.post(
+        "/auth/register",
+        json={
+            "username": "otheruser",
+            "email": "other@example.com",
+            "password": "securepass123",
+        },
+    )
+    response = client.post(
+        "/auth/login",
+        data={"username": "otheruser", "password": "securepass123"},
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# --- Root Endpoint ---
+
+
+class TestRootEndpoint:
+    """Tests for GET /."""
+
+    def test_should_return_api_info(self, client: TestClient) -> None:
+        response = client.get("/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "TaskFlow API"
+        assert data["version"] == "1.0.0"
+        assert data["docs"] == "/docs"
+
+
+# --- Task Endpoints ---
+
+
+class TestCreateTask:
+    """Tests for POST /tasks."""
+
+    def test_should_create_task_when_authenticated(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        response = client.post(
+            "/tasks/",
+            json={"title": "My Task", "description": "Details", "priority": "high"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == "My Task"
+        assert data["description"] == "Details"
+        assert data["priority"] == "high"
+        assert data["status"] == "todo"
+        assert "id" in data
+        assert "owner_id" in data
+
+    def test_should_reject_unauthenticated_create(self, client: TestClient) -> None:
+        response = client.post(
+            "/tasks/",
+            json={"title": "My Task"},
+        )
+        assert response.status_code == 401
+
+
+class TestListTasks:
+    """Tests for GET /tasks."""
+
+    def test_should_return_empty_list(self, client: TestClient) -> None:
+        response = client.get("/tasks/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_should_return_created_tasks(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        client.post(
+            "/tasks/", json={"title": "Task 1"}, headers=auth_headers
+        )
+        client.post(
+            "/tasks/", json={"title": "Task 2"}, headers=auth_headers
+        )
+        response = client.get("/tasks/")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+    def test_should_support_pagination(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        for i in range(5):
+            client.post(
+                "/tasks/", json={"title": f"Task {i}"}, headers=auth_headers
+            )
+        response = client.get("/tasks/?skip=1&limit=2")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+
+
+class TestGetTask:
+    """Tests for GET /tasks/{task_id}."""
+
+    def test_should_return_task_by_id(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "My Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.get(f"/tasks/{task_id}")
+        assert response.status_code == 200
+        assert response.json()["title"] == "My Task"
+
+    def test_should_return_404_for_nonexistent_task(
+        self, client: TestClient
+    ) -> None:
+        response = client.get("/tasks/9999")
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Task not found"
+
+
+class TestUpdateTask:
+    """Tests for PUT /tasks/{task_id}."""
+
+    def test_should_update_task_as_owner(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Old Title"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.put(
+            f"/tasks/{task_id}",
+            json={"title": "New Title", "status": "done"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == "New Title"
+        assert data["status"] == "done"
+
+    def test_should_reject_update_by_non_owner(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        other_auth_headers: dict,
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.put(
+            f"/tasks/{task_id}",
+            json={"title": "Hacked"},
+            headers=other_auth_headers,
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to update this task"
+
+    def test_should_reject_unauthenticated_update(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.put(
+            f"/tasks/{task_id}",
+            json={"title": "Hacked"},
+        )
+        assert response.status_code == 401
+
+    def test_should_return_404_for_nonexistent_task(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        response = client.put(
+            "/tasks/9999",
+            json={"title": "Nope"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteTask:
+    """Tests for DELETE /tasks/{task_id}."""
+
+    def test_should_delete_task_as_owner(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "To Delete"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.delete(f"/tasks/{task_id}", headers=auth_headers)
+        assert response.status_code == 204
+
+        get_resp = client.get(f"/tasks/{task_id}")
+        assert get_resp.status_code == 404
+
+    def test_should_reject_delete_by_non_owner(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        other_auth_headers: dict,
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.delete(
+            f"/tasks/{task_id}", headers=other_auth_headers
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to delete this task"
+
+    def test_should_reject_unauthenticated_delete(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.delete(f"/tasks/{task_id}")
+        assert response.status_code == 401
+
+    def test_should_return_404_for_nonexistent_task(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        response = client.delete("/tasks/9999", headers=auth_headers)
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
- Add `backend/src/taskflow/task_router.py` with 5 CRUD endpoints:
  - `GET /tasks/` -- list all tasks with pagination (skip/limit query params)
  - `GET /tasks/{task_id}` -- get task by ID (404 if not found)
  - `POST /tasks/` -- create task (requires auth, sets owner_id from JWT)
  - `PUT /tasks/{task_id}` -- update task (requires auth, owner-only with 403)
  - `DELETE /tasks/{task_id}` -- delete task (requires auth, owner-only with 403)
- Add `backend/src/taskflow/app.py` with FastAPI application:
  - Title "TaskFlow API", version "1.0.0"
  - Lifespan handler for database table creation on startup
  - Auth and task routers included
  - Root endpoint `GET /` returning API info
- Add `python-multipart` dependency (required by OAuth2PasswordRequestForm)
- Add 16 integration tests in `backend/tests/test_integration.py` using SQLite in-memory with StaticPool

## Test plan
- [x] All 16 integration tests pass: `cd backend && pytest tests/test_integration.py -v`
- [x] Root endpoint returns API info
- [x] Task CRUD: create, list, get by ID, update, delete
- [x] Auth required for create/update/delete (401 without token)
- [x] Owner-only update/delete (403 for non-owner)
- [x] 404 for nonexistent tasks on get/update/delete
- [x] Pagination support (skip/limit)
- [x] OpenAPI docs available at /docs

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)