### PR TITLE
feat: add shared fixtures and E2E integration tests (task-06)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,81 @@
+"""Shared test fixtures for TaskFlow API tests."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from taskflow.app import app
+from taskflow.database import Base, get_db
+
+
+@pytest.fixture()
+def test_db():
+    """Create an in-memory SQLite database session for testing."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    session = TestingSession()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(test_db: Session):
+    """Create a FastAPI TestClient with the test database override."""
+
+    def override_get_db():
+        try:
+            yield test_db
+        finally:
+            pass
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def auth_headers(client: TestClient) -> dict:
+    """Register a user, log in, and return auth headers with JWT token."""
+    client.post(
+        "/auth/register",
+        json={
+            "username": "testuser",
+            "email": "test@example.com",
+            "password": "securepass123",
+        },
+    )
+    response = client.post(
+        "/auth/login",
+        data={"username": "testuser", "password": "securepass123"},
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def other_auth_headers(client: TestClient) -> dict:
+    """Register a second user, log in, and return auth headers."""
+    client.post(
+        "/auth/register",
+        json={
+            "username": "otheruser",
+            "email": "other@example.com",
+            "password": "securepass123",
+        },
+    )
+    response = client.post(
+        "/auth/login",
+        data={"username": "otheruser", "password": "securepass123"},
+    )
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,81 +1,12 @@
-"""Integration tests for TaskFlow API endpoints."""
+"""End-to-end integration tests for TaskFlow API."""
 
-import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import StaticPool
-
-from taskflow.app import app
-from taskflow.database import Base, get_db
 
 
-@pytest.fixture()
-def client():
-    """Create a test client with an in-memory SQLite database."""
-    engine = create_engine(
-        "sqlite:///:memory:",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    Base.metadata.create_all(bind=engine)
-    TestingSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-    def override_get_db():
-        session = TestingSession()
-        try:
-            yield session
-        finally:
-            session.close()
-
-    app.dependency_overrides[get_db] = override_get_db
-    with TestClient(app) as c:
-        yield c
-    app.dependency_overrides.clear()
+# --- Health Check ---
 
 
-@pytest.fixture()
-def auth_headers(client: TestClient) -> dict:
-    """Register a user and return auth headers with JWT token."""
-    client.post(
-        "/auth/register",
-        json={
-            "username": "testuser",
-            "email": "test@example.com",
-            "password": "securepass123",
-        },
-    )
-    response = client.post(
-        "/auth/login",
-        data={"username": "testuser", "password": "securepass123"},
-    )
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
-
-
-@pytest.fixture()
-def other_auth_headers(client: TestClient) -> dict:
-    """Register a second user and return auth headers."""
-    client.post(
-        "/auth/register",
-        json={
-            "username": "otheruser",
-            "email": "other@example.com",
-            "password": "securepass123",
-        },
-    )
-    response = client.post(
-        "/auth/login",
-        data={"username": "otheruser", "password": "securepass123"},
-    )
-    token = response.json()["access_token"]
-    return {"Authorization": f"Bearer {token}"}
-
-
-# --- Root Endpoint ---
-
-
-class TestRootEndpoint:
+class TestHealthCheck:
     """Tests for GET /."""
 
     def test_should_return_api_info(self, client: TestClient) -> None:
@@ -87,58 +18,115 @@ class TestRootEndpoint:
         assert data["docs"] == "/docs"
 
 
-# --- Task Endpoints ---
+# --- Full Task Lifecycle ---
 
 
-class TestCreateTask:
-    """Tests for POST /tasks."""
+class TestFullTaskLifecycle:
+    """E2E test covering the complete task lifecycle."""
 
-    def test_should_create_task_when_authenticated(
+    def test_should_complete_full_task_lifecycle(
         self, client: TestClient, auth_headers: dict
     ) -> None:
-        response = client.post(
+        # Create a task
+        create_resp = client.post(
             "/tasks/",
-            json={"title": "My Task", "description": "Details", "priority": "high"},
+            json={"title": "Lifecycle Task", "description": "E2E test", "priority": "high"},
             headers=auth_headers,
         )
-        assert response.status_code == 201
-        data = response.json()
-        assert data["title"] == "My Task"
-        assert data["description"] == "Details"
-        assert data["priority"] == "high"
-        assert data["status"] == "todo"
-        assert "id" in data
-        assert "owner_id" in data
+        assert create_resp.status_code == 201
+        task = create_resp.json()
+        task_id = task["id"]
+        assert task["title"] == "Lifecycle Task"
+        assert task["status"] == "todo"
 
-    def test_should_reject_unauthenticated_create(self, client: TestClient) -> None:
-        response = client.post(
-            "/tasks/",
-            json={"title": "My Task"},
+        # List tasks — should contain the created task
+        list_resp = client.get("/tasks/")
+        assert list_resp.status_code == 200
+        tasks = list_resp.json()
+        assert len(tasks) == 1
+        assert tasks[0]["id"] == task_id
+
+        # Get task by ID
+        get_resp = client.get(f"/tasks/{task_id}")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["title"] == "Lifecycle Task"
+
+        # Update the task
+        update_resp = client.put(
+            f"/tasks/{task_id}",
+            json={"title": "Updated Task", "status": "done"},
+            headers=auth_headers,
         )
+        assert update_resp.status_code == 200
+        updated = update_resp.json()
+        assert updated["title"] == "Updated Task"
+        assert updated["status"] == "done"
+
+        # Delete the task
+        delete_resp = client.delete(f"/tasks/{task_id}", headers=auth_headers)
+        assert delete_resp.status_code == 204
+
+        # Verify task is gone (404)
+        gone_resp = client.get(f"/tasks/{task_id}")
+        assert gone_resp.status_code == 404
+
+
+# --- Unauthorized Access ---
+
+
+class TestUnauthorizedAccess:
+    """Tests for unauthenticated requests."""
+
+    def test_should_reject_create_without_token(self, client: TestClient) -> None:
+        response = client.post("/tasks/", json={"title": "No Auth"})
+        assert response.status_code == 401
+
+    def test_should_reject_update_without_token(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.put(f"/tasks/{task_id}", json={"title": "Hacked"})
+        assert response.status_code == 401
+
+    def test_should_reject_delete_without_token(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        response = client.delete(f"/tasks/{task_id}")
         assert response.status_code == 401
 
 
-class TestListTasks:
-    """Tests for GET /tasks."""
+# --- Multiple Tasks ---
 
-    def test_should_return_empty_list(self, client: TestClient) -> None:
-        response = client.get("/tasks/")
-        assert response.status_code == 200
-        assert response.json() == []
 
-    def test_should_return_created_tasks(
+class TestMultipleTasks:
+    """Tests for creating and listing multiple tasks."""
+
+    def test_should_create_and_list_multiple_tasks(
         self, client: TestClient, auth_headers: dict
     ) -> None:
-        client.post(
-            "/tasks/", json={"title": "Task 1"}, headers=auth_headers
-        )
-        client.post(
-            "/tasks/", json={"title": "Task 2"}, headers=auth_headers
-        )
-        response = client.get("/tasks/")
-        assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 2
+        for i in range(3):
+            resp = client.post(
+                "/tasks/",
+                json={"title": f"Task {i + 1}", "priority": "medium"},
+                headers=auth_headers,
+            )
+            assert resp.status_code == 201
+
+        list_resp = client.get("/tasks/")
+        assert list_resp.status_code == 200
+        tasks = list_resp.json()
+        assert len(tasks) == 3
+        titles = [t["title"] for t in tasks]
+        assert "Task 1" in titles
+        assert "Task 2" in titles
+        assert "Task 3" in titles
 
     def test_should_support_pagination(
         self, client: TestClient, auth_headers: dict
@@ -149,84 +137,127 @@ class TestListTasks:
             )
         response = client.get("/tasks/?skip=1&limit=2")
         assert response.status_code == 200
-        data = response.json()
-        assert len(data) == 2
+        assert len(response.json()) == 2
 
 
-class TestGetTask:
-    """Tests for GET /tasks/{task_id}."""
+# --- Update Task Status ---
 
-    def test_should_return_task_by_id(
+
+class TestUpdateTaskStatus:
+    """Tests for updating task status."""
+
+    def test_should_update_status_to_done(
         self, client: TestClient, auth_headers: dict
     ) -> None:
         create_resp = client.post(
-            "/tasks/", json={"title": "My Task"}, headers=auth_headers
+            "/tasks/", json={"title": "Pending Task"}, headers=auth_headers
         )
         task_id = create_resp.json()["id"]
-        response = client.get(f"/tasks/{task_id}")
-        assert response.status_code == 200
-        assert response.json()["title"] == "My Task"
+        assert create_resp.json()["status"] == "todo"
 
-    def test_should_return_404_for_nonexistent_task(
+        update_resp = client.put(
+            f"/tasks/{task_id}",
+            json={"status": "done"},
+            headers=auth_headers,
+        )
+        assert update_resp.status_code == 200
+        assert update_resp.json()["status"] == "done"
+        # Title should remain unchanged
+        assert update_resp.json()["title"] == "Pending Task"
+
+    def test_should_update_status_through_workflow(
+        self, client: TestClient, auth_headers: dict
+    ) -> None:
+        create_resp = client.post(
+            "/tasks/", json={"title": "Workflow Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+        assert create_resp.json()["status"] == "todo"
+
+        # Move to in_progress
+        resp1 = client.put(
+            f"/tasks/{task_id}",
+            json={"status": "in_progress"},
+            headers=auth_headers,
+        )
+        assert resp1.json()["status"] == "in_progress"
+
+        # Move to done
+        resp2 = client.put(
+            f"/tasks/{task_id}",
+            json={"status": "done"},
+            headers=auth_headers,
+        )
+        assert resp2.json()["status"] == "done"
+
+
+# --- Ownership Authorization ---
+
+
+class TestOwnershipAuthorization:
+    """Tests for task ownership enforcement."""
+
+    def test_should_forbid_non_owner_from_deleting(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        other_auth_headers: dict,
+    ) -> None:
+        # User A creates a task
+        create_resp = client.post(
+            "/tasks/", json={"title": "User A Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+
+        # User B tries to delete it
+        response = client.delete(f"/tasks/{task_id}", headers=other_auth_headers)
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to delete this task"
+
+        # Verify task still exists
+        get_resp = client.get(f"/tasks/{task_id}")
+        assert get_resp.status_code == 200
+
+    def test_should_forbid_non_owner_from_updating(
+        self,
+        client: TestClient,
+        auth_headers: dict,
+        other_auth_headers: dict,
+    ) -> None:
+        # User A creates a task
+        create_resp = client.post(
+            "/tasks/", json={"title": "User A Task"}, headers=auth_headers
+        )
+        task_id = create_resp.json()["id"]
+
+        # User B tries to update it
+        response = client.put(
+            f"/tasks/{task_id}",
+            json={"title": "Hacked Title"},
+            headers=other_auth_headers,
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to update this task"
+
+        # Verify task is unchanged
+        get_resp = client.get(f"/tasks/{task_id}")
+        assert get_resp.json()["title"] == "User A Task"
+
+
+# --- 404 Not Found ---
+
+
+class TestNotFound:
+    """Tests for nonexistent resource access."""
+
+    def test_should_return_404_for_get_nonexistent_task(
         self, client: TestClient
     ) -> None:
         response = client.get("/tasks/9999")
         assert response.status_code == 404
         assert response.json()["detail"] == "Task not found"
 
-
-class TestUpdateTask:
-    """Tests for PUT /tasks/{task_id}."""
-
-    def test_should_update_task_as_owner(
-        self, client: TestClient, auth_headers: dict
-    ) -> None:
-        create_resp = client.post(
-            "/tasks/", json={"title": "Old Title"}, headers=auth_headers
-        )
-        task_id = create_resp.json()["id"]
-        response = client.put(
-            f"/tasks/{task_id}",
-            json={"title": "New Title", "status": "done"},
-            headers=auth_headers,
-        )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["title"] == "New Title"
-        assert data["status"] == "done"
-
-    def test_should_reject_update_by_non_owner(
-        self,
-        client: TestClient,
-        auth_headers: dict,
-        other_auth_headers: dict,
-    ) -> None:
-        create_resp = client.post(
-            "/tasks/", json={"title": "Task"}, headers=auth_headers
-        )
-        task_id = create_resp.json()["id"]
-        response = client.put(
-            f"/tasks/{task_id}",
-            json={"title": "Hacked"},
-            headers=other_auth_headers,
-        )
-        assert response.status_code == 403
-        assert response.json()["detail"] == "Not authorized to update this task"
-
-    def test_should_reject_unauthenticated_update(
-        self, client: TestClient, auth_headers: dict
-    ) -> None:
-        create_resp = client.post(
-            "/tasks/", json={"title": "Task"}, headers=auth_headers
-        )
-        task_id = create_resp.json()["id"]
-        response = client.put(
-            f"/tasks/{task_id}",
-            json={"title": "Hacked"},
-        )
-        assert response.status_code == 401
-
-    def test_should_return_404_for_nonexistent_task(
+    def test_should_return_404_for_update_nonexistent_task(
         self, client: TestClient, auth_headers: dict
     ) -> None:
         response = client.put(
@@ -236,50 +267,7 @@ class TestUpdateTask:
         )
         assert response.status_code == 404
 
-
-class TestDeleteTask:
-    """Tests for DELETE /tasks/{task_id}."""
-
-    def test_should_delete_task_as_owner(
-        self, client: TestClient, auth_headers: dict
-    ) -> None:
-        create_resp = client.post(
-            "/tasks/", json={"title": "To Delete"}, headers=auth_headers
-        )
-        task_id = create_resp.json()["id"]
-        response = client.delete(f"/tasks/{task_id}", headers=auth_headers)
-        assert response.status_code == 204
-
-        get_resp = client.get(f"/tasks/{task_id}")
-        assert get_resp.status_code == 404
-
-    def test_should_reject_delete_by_non_owner(
-        self,
-        client: TestClient,
-        auth_headers: dict,
-        other_auth_headers: dict,
-    ) -> None:
-        create_resp = client.post(
-            "/tasks/", json={"title": "Task"}, headers=auth_headers
-        )
-        task_id = create_resp.json()["id"]
-        response = client.delete(
-            f"/tasks/{task_id}", headers=other_auth_headers
-        )
-        assert response.status_code == 403
-        assert response.json()["detail"] == "Not authorized to delete this task"
-
-    def test_should_reject_unauthenticated_delete(
-        self, client: TestClient, auth_headers: dict
-    ) -> None:
-        create_resp = client.post(
-            "/tasks/", json={"title": "Task"}, headers=auth_headers
-        )
-        task_id = create_resp.json()["id"]
-        response = client.delete(f"/tasks/{task_id}")
-        assert response.status_code == 401
-
-    def test_should_return_404_for_nonexistent_task(
+    def test_should_return_404_for_delete_nonexistent_task(
         self, client: TestClient, auth_headers: dict
     ) -> None:
         response = client.delete("/tasks/9999", headers=auth_headers)


### PR DESCRIPTION
## Summary
- Add `backend/tests/conftest.py` with reusable shared fixtures:
  - `test_db`: SQLite in-memory session with `StaticPool` for connection sharing
  - `client`: FastAPI `TestClient` with `get_db` dependency override
  - `auth_headers` / `other_auth_headers`: register + login helpers returning JWT bearer headers
- Rewrite `backend/tests/test_integration.py` with 14 E2E tests organized by scenario:
  - **Health check**: `GET /` returns API info
  - **Full lifecycle**: register -> login -> create -> list -> get -> update -> delete -> verify 404
  - **Unauthorized access**: 401 for create/update/delete without token
  - **Multiple tasks**: create 3 tasks and verify listing + pagination
  - **Status workflow**: todo -> in_progress -> done transitions
  - **Ownership**: 403 when non-owner tries to update or delete + verify task unchanged
  - **Not found**: 404 on get/update/delete nonexistent tasks

## Test plan
- [x] All 14 integration tests pass: `cd backend && pytest tests/test_integration.py -v`
- [x] All 80 backend tests pass: `cd backend && pytest -v` (no regressions)
- [x] conftest.py fixtures work with existing test files (test_auth, test_database, test_repositories, test_schemas)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)