### PR TITLE
feat: task-12 Feedback e Notificacoes com Mistica

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ import {
   ResponsiveLayout,
   Row,
   RowList,
-  Spinner,
+  SkeletonRectangle,
   Stack,
   Text2,
   Title1,
@@ -90,9 +90,20 @@ export default function DashboardPage() {
     return (
       <ProtectedRoute>
         <ResponsiveLayout>
-          <div style={{display: 'flex', justifyContent: 'center', paddingTop: 48}}>
-            <Spinner size={48} />
-          </div>
+          <Stack space={32}>
+            <Title1>Dashboard</Title1>
+            <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))', gap: 16}}>
+              {Array.from({length: 4}, (_, i) => (
+                <SkeletonRectangle key={i} height={120} />
+              ))}
+            </div>
+            <SkeletonRectangle height={80} />
+            <Stack space={16}>
+              {Array.from({length: 3}, (_, i) => (
+                <SkeletonRectangle key={i} height={64} />
+              ))}
+            </Stack>
+          </Stack>
         </ResponsiveLayout>
       </ProtectedRoute>
     );

--- a/frontend/src/app/tasks/[id]/edit/page.tsx
+++ b/frontend/src/app/tasks/[id]/edit/page.tsx
@@ -7,14 +7,16 @@ import {
   ButtonPrimary,
   ButtonSecondary,
   Callout,
+  ErrorFeedbackScreen,
   Form,
   ResponsiveLayout,
   Select,
-  Spinner,
+  SkeletonRectangle,
   Stack,
   TextField,
   Title1,
   useDialog,
+  useSnackbar,
 } from '@telefonica/mistica';
 import {useParams, useRouter} from 'next/navigation';
 import ProtectedRoute from '@/components/ProtectedRoute';
@@ -53,25 +55,41 @@ const PRIORITY_OPTIONS = [
   {value: 'high', text: 'Alta'},
 ] as const;
 
+function EditFormSkeleton() {
+  return (
+    <Boxed>
+      <Stack space={16}>
+        <SkeletonRectangle height={56} />
+        <SkeletonRectangle height={96} />
+        <SkeletonRectangle height={56} />
+        <SkeletonRectangle height={56} />
+        <SkeletonRectangle height={48} width={160} />
+      </Stack>
+    </Boxed>
+  );
+}
+
 export default function EditTaskPage() {
   const router = useRouter();
   const params = useParams();
   const taskId = params.id as string;
   const {confirm} = useDialog();
+  const {openSnackbar} = useSnackbar();
 
   const [task, setTask] = useState<Task | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
   const fetchTask = useCallback(async () => {
     setLoading(true);
-    setError(null);
+    setLoadError(false);
     try {
       const data = await api.get<Task>(`/tasks/${taskId}`);
       setTask(data);
     } catch {
-      setError('Erro ao carregar task.');
+      setLoadError(true);
     } finally {
       setLoading(false);
     }
@@ -92,8 +110,10 @@ export default function EditTaskPage() {
         priority: values['priority'] as string,
       };
       await api.put(`/tasks/${taskId}`, payload);
+      openSnackbar({message: 'Task atualizada com sucesso!'});
       router.push('/tasks');
     } catch {
+      openSnackbar({message: 'Erro ao atualizar task.', type: 'CRITICAL'});
       setError('Erro ao atualizar task. Verifique os dados e tente novamente.');
     } finally {
       setSubmitting(false);
@@ -110,13 +130,36 @@ export default function EditTaskPage() {
       onAccept: async () => {
         try {
           await api.delete(`/tasks/${taskId}`);
+          openSnackbar({message: 'Task excluida com sucesso!'});
           router.push('/tasks');
         } catch {
+          openSnackbar({message: 'Erro ao excluir task.', type: 'CRITICAL'});
           setError('Erro ao excluir task.');
         }
       },
     });
   };
+
+  if (!loading && loadError) {
+    return (
+      <ProtectedRoute>
+        <ErrorFeedbackScreen
+          title="Erro ao carregar task"
+          description="Nao foi possivel carregar os dados da task. Verifique sua conexao e tente novamente."
+          primaryButton={
+            <ButtonPrimary onPress={() => fetchTask()}>
+              Tentar novamente
+            </ButtonPrimary>
+          }
+          secondaryButton={
+            <ButtonSecondary onPress={() => router.push('/tasks')}>
+              Voltar para Tasks
+            </ButtonSecondary>
+          }
+        />
+      </ProtectedRoute>
+    );
+  }
 
   return (
     <ProtectedRoute>
@@ -133,9 +176,7 @@ export default function EditTaskPage() {
           )}
 
           {loading ? (
-            <div style={{display: 'flex', justifyContent: 'center', paddingTop: 48}}>
-              <Spinner size={48} />
-            </div>
+            <EditFormSkeleton />
           ) : task ? (
             <Boxed>
               <Stack space={16}>

--- a/frontend/src/app/tasks/new/page.tsx
+++ b/frontend/src/app/tasks/new/page.tsx
@@ -10,8 +10,10 @@ import {
   ResponsiveLayout,
   Select,
   Stack,
+  SuccessFeedbackScreen,
   TextField,
   Title1,
+  useSnackbar,
 } from '@telefonica/mistica';
 import {useRouter} from 'next/navigation';
 import ProtectedRoute from '@/components/ProtectedRoute';
@@ -38,8 +40,10 @@ const PRIORITY_OPTIONS = [
 
 export default function NewTaskPage() {
   const router = useRouter();
+  const {openSnackbar} = useSnackbar();
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const handleSubmit = async (values: Record<string, unknown>) => {
     setError(null);
@@ -52,13 +56,35 @@ export default function NewTaskPage() {
         priority: (values['priority'] as string) || 'medium',
       };
       await api.post('/tasks', payload);
-      router.push('/tasks');
+      setShowSuccess(true);
     } catch {
+      openSnackbar({message: 'Erro ao criar task. Tente novamente.', type: 'CRITICAL'});
       setError('Erro ao criar task. Verifique os dados e tente novamente.');
     } finally {
       setSubmitting(false);
     }
   };
+
+  if (showSuccess) {
+    return (
+      <ProtectedRoute>
+        <SuccessFeedbackScreen
+          title="Task criada com sucesso!"
+          description="Sua nova task foi adicionada a lista."
+          primaryButton={
+            <ButtonPrimary onPress={() => router.push('/tasks')}>
+              Ver Tasks
+            </ButtonPrimary>
+          }
+          secondaryButton={
+            <ButtonSecondary onPress={() => setShowSuccess(false)}>
+              Criar outra
+            </ButtonSecondary>
+          }
+        />
+      </ProtectedRoute>
+    );
+  }
 
   return (
     <ProtectedRoute>

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -5,12 +5,12 @@ import {
   ButtonPrimary,
   Callout,
   EmptyState,
+  IconClipboardRegular,
   ResponsiveLayout,
-  Spinner,
+  SkeletonRectangle,
   Stack,
   Tabs,
   Title1,
-  IconClipboardRegular,
 } from '@telefonica/mistica';
 import {useRouter} from 'next/navigation';
 import ProtectedRoute from '@/components/ProtectedRoute';
@@ -92,9 +92,11 @@ export default function TasksPage() {
           )}
 
           {loading ? (
-            <div style={{display: 'flex', justifyContent: 'center', paddingTop: 48}}>
-              <Spinner size={48} />
-            </div>
+            <Stack space={16}>
+              {Array.from({length: 3}, (_, i) => (
+                <SkeletonRectangle key={i} height={120} />
+              ))}
+            </Stack>
           ) : filteredTasks.length === 0 ? (
             <EmptyState
               title="Nenhuma task encontrada"


### PR DESCRIPTION
## Summary
- Snackbar notifications (useSnackbar) para todas as acoes CRUD de tasks
- SuccessFeedbackScreen apos criar task com opcoes de navegar ou criar outra
- ErrorFeedbackScreen quando falha ao carregar task no edit, com botao de retry
- Skeleton loading states (SkeletonRectangle) substituindo Spinners na lista de tasks, dashboard e formulario de edicao
- Spinner mantido apenas para submit de formularios (feedback inline)

## Test plan
- [ ] Criar task e verificar SuccessFeedbackScreen com botoes "Ver Tasks" e "Criar outra"
- [ ] Editar task e verificar snackbar "Task atualizada com sucesso!"
- [ ] Excluir task e verificar snackbar "Task excluida com sucesso!"
- [ ] Simular erro de rede e verificar snackbar CRITICAL e ErrorFeedbackScreen
- [ ] Verificar skeleton loading na lista de tasks (3 retangulos)
- [ ] Verificar skeleton loading no dashboard (4 cards + progress + rows)
- [ ] Verificar skeleton loading no edit form (5 retangulos simulando campos)
- [ ] Build passando sem erros TypeScript

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)